### PR TITLE
fix(engine): Locs changing (i.e., a tree into a stump) now uses more efficient logic

### DIFF
--- a/src/engine/entity/Loc.ts
+++ b/src/engine/entity/Loc.ts
@@ -20,6 +20,10 @@ export default class Loc extends NonPathingEntity {
         return this.info;
     }
 
+    isChanged(): boolean {
+        return this.tempinfo !== -1;
+    }
+
     get type(): number {
         return this.currentinfo & 0x3fff;
     }
@@ -38,5 +42,9 @@ export default class Loc extends NonPathingEntity {
         } else if (this.lifecycle === EntityLifeCycle.DESPAWN) {
             this.info = (type & 0x3fff) | ((shape & 0x1f) << 14) | ((angle & 0x3) << 19);
         }
+    }
+
+    revert() {
+        this.tempinfo = -1;
     }
 }

--- a/src/engine/entity/Loc.ts
+++ b/src/engine/entity/Loc.ts
@@ -3,23 +3,40 @@ import NonPathingEntity from '#/engine/entity/NonPathingEntity.js';
 
 export default class Loc extends NonPathingEntity {
     // constructor properties
-    private readonly info: number;
+    private info: number;
+    private tempinfo: number;
 
     constructor(level: number, x: number, z: number, width: number, length: number, lifecycle: EntityLifeCycle, type: number, shape: number, angle: number) {
         super(level, x, z, width, length, lifecycle);
         // 16383, 31, 3
         this.info = (type & 0x3fff) | ((shape & 0x1f) << 14) | ((angle & 0x3) << 19);
+        this.tempinfo = -1;
+    }
+
+    private get currentinfo() {
+        if (this.tempinfo !== -1) {
+            return this.tempinfo;
+        }
+        return this.info;
     }
 
     get type(): number {
-        return this.info & 0x3fff;
+        return this.currentinfo & 0x3fff;
     }
 
     get shape(): number {
-        return (this.info >> 14) & 0x1f;
+        return (this.currentinfo >> 14) & 0x1f;
     }
 
     get angle(): number {
-        return (this.info >> 19) & 0x3;
+        return (this.currentinfo >> 19) & 0x3;
+    }
+
+    change(type: number, shape: number, angle: number) {
+        if (this.lifecycle === EntityLifeCycle.RESPAWN) {
+            this.tempinfo = (type & 0x3fff) | ((shape & 0x1f) << 14) | ((angle & 0x3) << 19);
+        } else if (this.lifecycle === EntityLifeCycle.DESPAWN) {
+            this.info = (type & 0x3fff) | ((shape & 0x1f) << 14) | ((angle & 0x3) << 19);
+        }
     }
 }

--- a/src/engine/entity/PathingEntity.ts
+++ b/src/engine/entity/PathingEntity.ts
@@ -509,16 +509,23 @@ export default abstract class PathingEntity extends Entity {
         }
     }
 
-    setInteraction(interaction: Interaction, target: Entity, op: TargetOp, subject?: TargetSubject): boolean {
+    setInteraction(interaction: Interaction, target: Entity, op: TargetOp, com?: number): boolean {
         if (!target.isValid(this instanceof Player ? this.hash64 : undefined)) {
             return false;
         }
 
         this.target = target;
         this.targetOp = op;
-        this.targetSubject = subject ?? { type: -1, com: -1 };
         this.apRange = 10;
         this.apRangeCalled = false;
+
+        this.targetSubject.com = com ? com : -1;
+        // Remember initial target type for validation
+        if (target instanceof Npc || target instanceof Loc || target instanceof Obj) {
+            this.targetSubject.type = target.type;
+        } else {
+            this.targetSubject.type = -1;
+        }
 
         this.focus(CoordGrid.fine(target.x, target.width), CoordGrid.fine(target.z, target.length), target instanceof NonPathingEntity && interaction === Interaction.ENGINE);
 

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1121,8 +1121,8 @@ export default class Player extends PathingEntity {
             return false;
         }
 
-        // This is effectively checking if the npc did a changetype
-        if (this.target instanceof Npc && this.targetSubject.type !== -1 && World.getNpcByUid((this.targetSubject.type << 16) | this.target.nid) === null) {
+        // This is effectively checking if the Npc or Loc did a changetype
+        if ((this.target instanceof Npc || this.target instanceof Loc) && this.targetSubject.type !== this.target.type) {
             return false;
         }
 

--- a/src/engine/entity/Player.ts
+++ b/src/engine/entity/Player.ts
@@ -1,7 +1,6 @@
 import 'dotenv/config';
 
-import { CollisionType , CollisionFlag } from '@2004scape/rsmod-pathfinder';
-
+import { CollisionType, CollisionFlag } from '@2004scape/rsmod-pathfinder';
 
 import Component from '#/cache/config/Component.js';
 import FontType from '#/cache/config/FontType.js';
@@ -934,9 +933,6 @@ export default class Player extends PathingEntity {
             typeId = type.id;
             categoryId = type.category;
         }
-        if (this.targetSubject.type !== -1) {
-            typeId = this.targetSubject.type;
-        }
         if (this.targetSubject.com !== -1) {
             typeId = this.targetSubject.com;
         }
@@ -957,9 +953,6 @@ export default class Player extends PathingEntity {
             const type = this.target instanceof Npc ? NpcType.get(this.target.type) : this.target instanceof Loc ? LocType.get(this.target.type) : ObjType.get(this.target.type);
             typeId = type.id;
             categoryId = type.category;
-        }
-        if (this.targetSubject.type !== -1) {
-            typeId = this.targetSubject.type;
         }
         if (this.targetSubject.com !== -1) {
             typeId = this.targetSubject.com;

--- a/src/engine/script/handlers/LocOps.ts
+++ b/src/engine/script/handlers/LocOps.ts
@@ -14,7 +14,6 @@ import { CommandHandlers } from '#/engine/script/ScriptRunner.js';
 import { check, CoordValid, DurationValid, LocAngleValid, LocShapeValid, LocTypeValid, ParamTypeValid, SeqTypeValid } from '#/engine/script/ScriptValidators.js';
 import World from '#/engine/World.js';
 
-
 const LocOps: CommandHandlers = {
     [ScriptOpcode.LOC_ADD]: state => {
         const [coord, type, angle, shape, duration] = state.popInts(5);
@@ -59,23 +58,7 @@ const LocOps: CommandHandlers = {
         const locType: LocType = check(id, LocTypeValid);
         check(duration, DurationValid);
 
-        World.removeLoc(state.activeLoc, duration);
-
-        // const loc = new Loc(state.activeLoc.level, state.activeLoc.x, state.activeLoc.z, locType.width, locType.length, EntityLifeCycle.DESPAWN, id, state.activeLoc.shape, state.activeLoc.angle);
-        // World.addLoc(loc, duration);
-
-        const { level, x, z, angle, shape } = state.activeLoc;
-        const created: Loc = new Loc(level, x, z, locType.width, locType.length, EntityLifeCycle.DESPAWN, locType.id, shape, angle);
-        const locs: IterableIterator<Loc> = World.gameMap.getZone(x, z, level).getLocsUnsafe(CoordGrid.packZoneCoord(x, z));
-        for (const loc of locs) {
-            if (loc !== created && loc.angle === angle && loc.shape === shape) {
-                World.removeLoc(loc, duration);
-                break;
-            }
-        }
-        World.addLoc(created, duration);
-        state.activeLoc = created;
-        state.pointerAdd(ActiveLoc[state.intOperand]);
+        World.changeLoc(state.activeLoc, id, duration);
     }),
 
     [ScriptOpcode.LOC_COORD]: checkedHandler(ActiveLoc, state => {

--- a/src/engine/script/handlers/PlayerOps.ts
+++ b/src/engine/script/handlers/PlayerOps.ts
@@ -369,14 +369,14 @@ const PlayerOps: CommandHandlers = {
             return;
         }
         state.activePlayer.stopAction();
-        state.activePlayer.setInteraction(Interaction.SCRIPT, state.activeNpc, ServerTriggerType.APNPC1 + type, { type: state.activeNpc.type, com: -1 });
+        state.activePlayer.setInteraction(Interaction.SCRIPT, state.activeNpc, ServerTriggerType.APNPC1 + type);
     }),
 
     // https://x.com/JagexAsh/status/1791472651623370843
     [ScriptOpcode.P_OPNPCT]: checkedHandler(ProtectedActivePlayer, state => {
         const spellId: number = check(state.popInt(), NumberNotNull);
         state.activePlayer.stopAction();
-        state.activePlayer.setInteraction(Interaction.SCRIPT, state.activeNpc, ServerTriggerType.APNPCT, { type: state.activeNpc.type, com: spellId });
+        state.activePlayer.setInteraction(Interaction.SCRIPT, state.activeNpc, ServerTriggerType.APNPCT);
     }),
 
     // https://x.com/JagexAsh/status/1389465615631519744
@@ -1020,7 +1020,7 @@ const PlayerOps: CommandHandlers = {
             return;
         }
         state.activePlayer.stopAction();
-        state.activePlayer.setInteraction(Interaction.SCRIPT, target, ServerTriggerType.APPLAYERT, { type: -1, com: spellId });
+        state.activePlayer.setInteraction(Interaction.SCRIPT, target, ServerTriggerType.APPLAYERT, spellId);
     }),
 
     // https://x.com/JagexAsh/status/1799020087086903511

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -247,7 +247,7 @@ export default class Zone {
         if (loc.lifecycle === EntityLifeCycle.DESPAWN) {
             this.locs.addTail(loc);
         }
-
+        loc.revert();
         loc.isActive = true;
         this.queueEvent(loc, new ZoneEvent(ZoneEventType.ENCLOSED, -1n, new LocAddChange(coord, loc.type, loc.shape, loc.angle)));
     }

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -114,6 +114,9 @@ export default class Zone {
             }
             if (loc.lifecycle === EntityLifeCycle.DESPAWN) {
                 World.removeLoc(loc, 0);
+            } else if (loc.lifecycle === EntityLifeCycle.RESPAWN && loc.isChanged()) {
+                console.log('reverting loc');
+                World.revertLoc(loc);
             } else if (loc.lifecycle === EntityLifeCycle.RESPAWN) {
                 World.addLoc(loc, 0);
             }
@@ -240,7 +243,11 @@ export default class Zone {
         }
 
         loc.isActive = true;
+        this.queueEvent(loc, new ZoneEvent(ZoneEventType.ENCLOSED, -1n, new LocAddChange(coord, loc.type, loc.shape, loc.angle)));
+    }
 
+    changeLoc(loc: Loc) {
+        const coord: number = CoordGrid.packZoneCoord(loc.x, loc.z);
         this.queueEvent(loc, new ZoneEvent(ZoneEventType.ENCLOSED, -1n, new LocAddChange(coord, loc.type, loc.shape, loc.angle)));
     }
 

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -115,7 +115,6 @@ export default class Zone {
             if (loc.lifecycle === EntityLifeCycle.DESPAWN) {
                 World.removeLoc(loc, 0);
             } else if (loc.lifecycle === EntityLifeCycle.RESPAWN && loc.isChanged()) {
-                console.log('reverting loc');
                 World.revertLoc(loc);
             } else if (loc.lifecycle === EntityLifeCycle.RESPAWN) {
                 World.addLoc(loc, 0);
@@ -174,9 +173,16 @@ export default class Zone {
             if (loc.lastLifecycleTick === currentTick) {
                 continue;
             }
+            // Send dynamic locs to the client
             if (loc.lifecycle === EntityLifeCycle.DESPAWN && loc.checkLifeCycle(currentTick)) {
                 player.write(new LocAddChange(CoordGrid.packZoneCoord(loc.x, loc.z), loc.type, loc.shape, loc.angle));
-            } else if (loc.lifecycle === EntityLifeCycle.RESPAWN && !loc.checkLifeCycle(currentTick)) {
+            }
+            // Send 'changed' static locs to the client
+            else if (loc.lifecycle === EntityLifeCycle.RESPAWN && loc.isChanged()) {
+                player.write(new LocAddChange(CoordGrid.packZoneCoord(loc.x, loc.z), loc.type, loc.shape, loc.angle));
+            }
+            // Inform the client that a static loc is not currently active
+            else if (loc.lifecycle === EntityLifeCycle.RESPAWN && !loc.checkLifeCycle(currentTick)) {
                 player.write(new LocDel(CoordGrid.packZoneCoord(loc.x, loc.z), loc.shape, loc.angle));
             }
         }

--- a/src/network/rs225/client/handler/OpLocTHandler.ts
+++ b/src/network/rs225/client/handler/OpLocTHandler.ts
@@ -41,7 +41,7 @@ export default class OpLocTHandler extends MessageHandler<OpLocT> {
         }
 
         player.clearPendingAction();
-        player.setInteraction(Interaction.ENGINE, loc, ServerTriggerType.APLOCT, { type: loc.type, com: spellComId });
+        player.setInteraction(Interaction.ENGINE, loc, ServerTriggerType.APLOCT, spellComId);
         player.opcalled = true;
         return true;
     }

--- a/src/network/rs225/client/handler/OpNpcHandler.ts
+++ b/src/network/rs225/client/handler/OpNpcHandler.ts
@@ -50,7 +50,7 @@ export default class OpNpcHandler extends MessageHandler<OpNpc> {
         }
 
         player.clearPendingAction();
-        player.setInteraction(Interaction.ENGINE, npc, mode, { type: npc.type, com: -1 });
+        player.setInteraction(Interaction.ENGINE, npc, mode);
         player.opcalled = true;
         return true;
     }

--- a/src/network/rs225/client/handler/OpNpcTHandler.ts
+++ b/src/network/rs225/client/handler/OpNpcTHandler.ts
@@ -37,7 +37,7 @@ export default class OpNpcTHandler extends MessageHandler<OpNpcT> {
         }
 
         player.clearPendingAction();
-        player.setInteraction(Interaction.ENGINE, npc, ServerTriggerType.APNPCT, { type: npc.type, com: spellComId });
+        player.setInteraction(Interaction.ENGINE, npc, ServerTriggerType.APNPCT, spellComId);
         player.opcalled = true;
         return true;
     }

--- a/src/network/rs225/client/handler/OpNpcUHandler.ts
+++ b/src/network/rs225/client/handler/OpNpcUHandler.ts
@@ -62,7 +62,7 @@ export default class OpNpcUHandler extends MessageHandler<OpNpcU> {
         player.lastUseItem = item;
         player.lastUseSlot = slot;
 
-        player.setInteraction(Interaction.ENGINE, npc, ServerTriggerType.APNPCU, { type: npc.type, com: -1 });
+        player.setInteraction(Interaction.ENGINE, npc, ServerTriggerType.APNPCU);
         player.opcalled = true;
         return true;
     }

--- a/src/network/rs225/client/handler/OpObjTHandler.ts
+++ b/src/network/rs225/client/handler/OpObjTHandler.ts
@@ -41,7 +41,7 @@ export default class OpObjTHandler extends MessageHandler<OpObjT> {
         }
 
         player.clearPendingAction();
-        player.setInteraction(Interaction.ENGINE, obj, ServerTriggerType.APOBJT, { type: obj.type, com: spellComId });
+        player.setInteraction(Interaction.ENGINE, obj, ServerTriggerType.APOBJT, spellComId);
         player.opcalled = true;
         return true;
     }

--- a/src/network/rs225/client/handler/OpPlayerTHandler.ts
+++ b/src/network/rs225/client/handler/OpPlayerTHandler.ts
@@ -37,7 +37,7 @@ export default class OpPlayerTHandler extends MessageHandler<OpPlayerT> {
         }
 
         player.clearPendingAction();
-        player.setInteraction(Interaction.ENGINE, other, ServerTriggerType.APPLAYERT, { type: -1, com: spellComId });
+        player.setInteraction(Interaction.ENGINE, other, ServerTriggerType.APPLAYERT, spellComId);
         player.opcalled = true;
         return true;
     }

--- a/src/network/rs225/client/handler/OpPlayerUHandler.ts
+++ b/src/network/rs225/client/handler/OpPlayerUHandler.ts
@@ -61,7 +61,7 @@ export default class OpPlayerUHandler extends MessageHandler<OpPlayerU> {
 
         player.lastUseSlot = slot;
 
-        player.setInteraction(Interaction.ENGINE, other, ServerTriggerType.APPLAYERU, { type: item, com: -1 });
+        player.setInteraction(Interaction.ENGINE, other, ServerTriggerType.APPLAYERU, item);
         player.opcalled = true;
         return true;
     }


### PR DESCRIPTION
When calling `loc_change` in runescript, it now changes the type of the Loc in memory, rather than constructing a new one. This is testably authentic to how osrs handles it

- Locs have a new method `change`
    - When called on a dynamic loc, this will overwrite the `info`  bits
    - When called on a static loc, this will set the `tempinfo` bits
- Player now validates against original loc `type` before allowing interactions
- World and Zone have functionality to keep track of changed static locs
  