### PR TITLE
fix(engine): Loc add now uses new changeloc logic and Obj and Loc events are sped up

### DIFF
--- a/data/src/scripts/_test/scripts/cheats/cheat_zone.rs2
+++ b/data/src/scripts/_test/scripts/cheats/cheat_zone.rs2
@@ -19,3 +19,13 @@ if (p_finduid(uid) = true) {
     loc_add(0_37_55_32_28, loc_1276, 0, centrepiece_straight, 10);
     loc_add(0_37_55_32_27, loc_1276, 0, centrepiece_straight, 10);
 }
+
+
+[debugproc,loc_add_del]
+if (p_finduid(uid) = true) {
+    p_telejump(0_37_55_32_30);
+    p_delay(0);
+    loc_add(0_37_55_32_30, loc_1276, 0, centrepiece_straight, 10);
+    loc_del(100);
+}
+

--- a/data/src/scripts/skill_firemaking/scripts/firemaking.rs2
+++ b/data/src/scripts/skill_firemaking/scripts/firemaking.rs2
@@ -114,7 +114,7 @@ facesquare($fire_coord);
 mes("The fire catches and the logs begin to burn.");
 def_int $delay = calc(100 + random(100)); // firemaking length: https://archive.is/zF5hb
 loc_add($fire_coord, loc_2732, 1, centrepiece_straight, $delay);
-world_delay($delay);
+world_delay(add($delay, -2));
 obj_addall($fire_coord, ashes, 1, 100);
 
 [proc,area_allow_loc_add](coord $coord)(boolean)

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1308,6 +1308,15 @@ class World {
         }
     }
 
+    trackLocObj(entity: Loc | Obj, zone: Zone, duration: number): void {
+        // In OSRS I suspect they use a counter per Loc/Obj to keep track of events rather than scheduling for a tick
+        // In 2004scape, we schedule for a tick. Scheduling for a tick ends up naturally 1 tick slower, so we do a -1 to compensate to match OSRS behavior
+        // - Bea5
+        entity.setLifeCycle(this.currentTick + duration - 1);
+        this.trackZone(this.currentTick + duration - 1, zone);
+        this.trackZone(this.currentTick, zone);
+    }
+
     addLoc(loc: Loc, duration: number): void {
         // printDebug(`[World] addLoc => name: ${LocType.get(loc.type).name}, duration: ${duration}`);
         const type: LocType = LocType.get(loc.type);
@@ -1317,9 +1326,7 @@ class World {
 
         const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.addLoc(loc);
-        loc.setLifeCycle(this.currentTick + duration);
-        this.trackZone(this.currentTick + duration, zone);
-        this.trackZone(this.currentTick, zone);
+        this.trackLocObj(loc, zone, duration);
     }
 
     changeLoc(loc: Loc, typeID: number, shape: number, angle: number, duration: number) {
@@ -1341,9 +1348,7 @@ class World {
         // Notify zone that loc has been changed
         const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.changeLoc(loc);
-        loc.setLifeCycle(this.currentTick + duration);
-        this.trackZone(this.currentTick + duration, zone);
-        this.trackZone(this.currentTick, zone);
+        this.trackLocObj(loc, zone, duration);
     }
 
     mergeLoc(loc: Loc, player: Player, startCycle: number, endCycle: number, south: number, east: number, north: number, west: number): void {
@@ -1369,9 +1374,7 @@ class World {
 
         const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);
         zone.removeLoc(loc);
-        loc.setLifeCycle(this.currentTick + duration);
-        this.trackZone(this.currentTick + duration, zone);
-        this.trackZone(this.currentTick, zone);
+        this.trackLocObj(loc, zone, duration);
     }
 
     revertLoc(loc: Loc) {
@@ -1405,16 +1408,11 @@ class World {
         if (receiver64 !== Obj.NO_RECEIVER) {
             // objs with a receiver always attempt to reveal 100 ticks after being dropped.
             // items that can't be revealed (untradable, members obj in f2p) will be skipped in revealObj
-            const reveal: number = this.currentTick + Obj.REVEAL;
-            obj.setLifeCycle(reveal);
-            this.trackZone(reveal, zone);
-            this.trackZone(this.currentTick, zone);
+            this.trackLocObj(obj, zone, Obj.REVEAL);
             obj.receiver64 = receiver64;
             obj.reveal = duration;
         } else {
-            obj.setLifeCycle(this.currentTick + duration);
-            this.trackZone(this.currentTick + duration, zone);
-            this.trackZone(this.currentTick, zone);
+            this.trackLocObj(obj, zone, duration);
         }
     }
 
@@ -1444,9 +1442,7 @@ class World {
         const zone: Zone = this.gameMap.getZone(obj.x, obj.z, obj.level);
         const adjustedDuration = this.scaleByPlayerCount(duration);
         zone.removeObj(obj);
-        obj.setLifeCycle(this.currentTick + adjustedDuration);
-        this.trackZone(this.currentTick + adjustedDuration, zone);
-        this.trackZone(this.currentTick, zone);
+        this.trackLocObj(obj, zone, adjustedDuration);
     }
 
     animMap(level: number, x: number, z: number, spotanim: number, height: number, delay: number): void {

--- a/src/engine/World.ts
+++ b/src/engine/World.ts
@@ -1322,7 +1322,7 @@ class World {
         this.trackZone(this.currentTick, zone);
     }
 
-    changeLoc(loc: Loc, typeID: number, duration: number) {
+    changeLoc(loc: Loc, typeID: number, shape: number, angle: number, duration: number) {
         // Remove previous collision from game world
         const fromType: LocType = LocType.get(loc.type);
         if (fromType.blockwalk) {
@@ -1336,7 +1336,7 @@ class World {
         }
 
         // Update loc to new type
-        loc.change(typeID, loc.shape, loc.angle);
+        loc.change(typeID, shape, angle);
 
         // Notify zone that loc has been changed
         const zone: Zone = this.gameMap.getZone(loc.x, loc.z, loc.level);

--- a/src/engine/entity/Loc.ts
+++ b/src/engine/entity/Loc.ts
@@ -1,3 +1,5 @@
+import { locShapeLayer } from '@2004scape/rsmod-pathfinder';
+
 import EntityLifeCycle from '#/engine/entity/EntityLifeCycle.js';
 import NonPathingEntity from '#/engine/entity/NonPathingEntity.js';
 
@@ -8,8 +10,7 @@ export default class Loc extends NonPathingEntity {
 
     constructor(level: number, x: number, z: number, width: number, length: number, lifecycle: EntityLifeCycle, type: number, shape: number, angle: number) {
         super(level, x, z, width, length, lifecycle);
-        // 16383, 31, 3
-        this.info = (type & 0x3fff) | ((shape & 0x1f) << 14) | ((angle & 0x3) << 19);
+        this.info = this.packInfo(type, shape, angle);
         this.tempinfo = -1;
     }
 
@@ -18,6 +19,12 @@ export default class Loc extends NonPathingEntity {
             return this.tempinfo;
         }
         return this.info;
+    }
+
+    private packInfo(type: number, shape: number, angle: number): number {
+        const layer: number = locShapeLayer(shape);
+        // 16383, 31, 3, 3
+        return (type & 0x3fff) | ((shape & 0x1f) << 14) | ((angle & 0x3) << 19) | ((layer & 0x3) << 21);
     }
 
     isChanged(): boolean {
@@ -36,11 +43,18 @@ export default class Loc extends NonPathingEntity {
         return (this.currentinfo >> 19) & 0x3;
     }
 
+    get layer(): number {
+        return (this.info >> 21) & 0x3;
+    }
+
     change(type: number, shape: number, angle: number) {
+        // Static locs set the temp bits
         if (this.lifecycle === EntityLifeCycle.RESPAWN) {
-            this.tempinfo = (type & 0x3fff) | ((shape & 0x1f) << 14) | ((angle & 0x3) << 19);
-        } else if (this.lifecycle === EntityLifeCycle.DESPAWN) {
-            this.info = (type & 0x3fff) | ((shape & 0x1f) << 14) | ((angle & 0x3) << 19);
+            this.tempinfo = this.packInfo(type, shape, angle);
+        }
+        // Dynamic locs set their real bits
+        else if (this.lifecycle === EntityLifeCycle.DESPAWN) {
+            this.info = this.packInfo(type, shape, angle);
         }
     }
 

--- a/src/engine/entity/NonPathingEntity.ts
+++ b/src/engine/entity/NonPathingEntity.ts
@@ -4,12 +4,4 @@ export default abstract class NonPathingEntity extends Entity {
     resetEntity(_respawn: boolean) {
         // nothing happens here
     }
-
-    setLifeCycle(tick: number): void {
-        // In OSRS I suspect they use a counter per Loc/Obj to keep track of events rather than scheduling for a tick
-        // In 2004scape, we schedule for a tick. Scheduling for a tick ends up naturally 1 tick slower, so we do a -1 to compensate to match OSRS behavior
-        // - Bea5
-        this.lifecycleTick = tick - 1;
-        this.lastLifecycleTick = World.currentTick;
-    }
 }

--- a/src/engine/entity/NonPathingEntity.ts
+++ b/src/engine/entity/NonPathingEntity.ts
@@ -1,7 +1,15 @@
 import Entity from '#/engine/entity/Entity.js';
-
+import World from '#/engine/World.js';
 export default abstract class NonPathingEntity extends Entity {
     resetEntity(_respawn: boolean) {
         // nothing happens here
+    }
+
+    setLifeCycle(tick: number): void {
+        // In OSRS I suspect they use a counter per Loc/Obj to keep track of events rather than scheduling for a tick
+        // In 2004scape, we schedule for a tick. Scheduling for a tick ends up naturally 1 tick slower, so we do a -1 to compensate to match OSRS behavior
+        // - Bea5
+        this.lifecycleTick = tick - 1;
+        this.lastLifecycleTick = World.currentTick;
     }
 }

--- a/src/engine/script/handlers/LocOps.ts
+++ b/src/engine/script/handlers/LocOps.ts
@@ -1,4 +1,4 @@
-import { LocAngle, LocShape } from '@2004scape/rsmod-pathfinder';
+import { LocAngle, LocShape, locShapeLayer } from '@2004scape/rsmod-pathfinder';
 
 import LocType from '#/cache/config/LocType.js';
 import { ParamHelper } from '#/cache/config/ParamHelper.js';
@@ -22,16 +22,21 @@ const LocOps: CommandHandlers = {
         const locType: LocType = check(type, LocTypeValid);
         const locAngle: LocAngle = check(angle, LocAngleValid);
         const locShape: LocShape = check(shape, LocShapeValid);
+        const locLayer = locShapeLayer(locShape);
         check(duration, DurationValid);
 
-        const created: Loc = new Loc(position.level, position.x, position.z, locType.width, locType.length, EntityLifeCycle.DESPAWN, locType.id, locShape, locAngle);
+        // Search through zone and change a loc if it's on the same layer
         const locs: IterableIterator<Loc> = World.gameMap.getZone(position.x, position.z, position.level).getLocsUnsafe(CoordGrid.packZoneCoord(position.x, position.z));
         for (const loc of locs) {
-            if (loc !== created && loc.angle === locAngle && loc.shape === locShape) {
-                World.removeLoc(loc, duration);
-                break;
+            if (loc.layer === locLayer) {
+                World.changeLoc(loc, type, locShape, locAngle, duration);
+                state.activeLoc = loc;
+                state.pointerAdd(ActiveLoc[state.intOperand]);
+                return;
             }
         }
+
+        const created: Loc = new Loc(position.level, position.x, position.z, locType.width, locType.length, EntityLifeCycle.DESPAWN, locType.id, locShape, locAngle);
         World.addLoc(created, duration);
         state.activeLoc = created;
         state.pointerAdd(ActiveLoc[state.intOperand]);
@@ -58,7 +63,7 @@ const LocOps: CommandHandlers = {
         const locType: LocType = check(id, LocTypeValid);
         check(duration, DurationValid);
 
-        World.changeLoc(state.activeLoc, id, duration);
+        World.changeLoc(state.activeLoc, id, state.activeLoc.shape, state.activeLoc.angle, duration);
     }),
 
     [ScriptOpcode.LOC_COORD]: checkedHandler(ActiveLoc, state => {

--- a/src/engine/zone/Zone.ts
+++ b/src/engine/zone/Zone.ts
@@ -174,16 +174,16 @@ export default class Zone {
                 continue;
             }
             // Send dynamic locs to the client
-            if (loc.lifecycle === EntityLifeCycle.DESPAWN && loc.checkLifeCycle(currentTick)) {
+            if (loc.lifecycle === EntityLifeCycle.DESPAWN && loc.isValid()) {
                 player.write(new LocAddChange(CoordGrid.packZoneCoord(loc.x, loc.z), loc.type, loc.shape, loc.angle));
+            }
+            // Inform the client that a static loc is not currently active
+            else if (loc.lifecycle === EntityLifeCycle.RESPAWN && !loc.isValid()) {
+                player.write(new LocDel(CoordGrid.packZoneCoord(loc.x, loc.z), loc.shape, loc.angle));
             }
             // Send 'changed' static locs to the client
             else if (loc.lifecycle === EntityLifeCycle.RESPAWN && loc.isChanged()) {
                 player.write(new LocAddChange(CoordGrid.packZoneCoord(loc.x, loc.z), loc.type, loc.shape, loc.angle));
-            }
-            // Inform the client that a static loc is not currently active
-            else if (loc.lifecycle === EntityLifeCycle.RESPAWN && !loc.checkLifeCycle(currentTick)) {
-                player.write(new LocDel(CoordGrid.packZoneCoord(loc.x, loc.z), loc.shape, loc.angle));
             }
         }
     }


### PR DESCRIPTION
`loc_add` now will run through World.changeloc() if there is a layer conflict

Obj and Loc events are sped up by 1 tick